### PR TITLE
upgrade node to version 9

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:latest
+FROM node:9
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
close #16 
Node 6 is obsolete, upgrading to Node 9